### PR TITLE
Add monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,18 @@ i = new Iterate({
   waitTime: 2,
   handler: (watchDog, state) => {
     console.log(`do some work`);
+
     watchDog.touch(); // tell Iterate that we`re doing work still
+
     console.log(`still working`);
     watchDog.touch();
+
     return new Promise((res, rej) => {
       console.log(`Almost done`);
       watchDog.touch();
       setTimeout(res, 2);
     });
   },
-
 });
 
 i.start();
@@ -51,7 +53,7 @@ the following properties:
   Is passed in a watchdog and state object reference
 * `waitTime`: number of seconds between the conclusion of one iteration
   and commencement of another.
-* `maxIterations` (optional, default infinite): Complete up to this many 
+* `maxIterations` (optional, default infinite): Complete up to this many
   iterations and then successfully exit.  Failed iterations count.
 * `maxFailures` (optional, default 7): When this number of failures occur
   in consecutive iterations, treat as an error
@@ -63,6 +65,8 @@ the following properties:
 * `dmsConfig` (optional): provide information of a deadman's snitch to
   inform of the completion of an iteration.  This is an object of shape
   `{apiKey: '...', snitchUrl: '...'}`
+* `monitor` (optional): instance of `taskcluster-lib-monitor` prefix with a
+  name appropriate for this iterate instance.
 
 The code to run is called a handler.  A handler is a function which returns a
 promise (e.g. async function).  This function is passed in the arguments
@@ -71,7 +75,7 @@ promise (e.g. async function).  This function is passed in the arguments
 The `watchdog` parameter is basically a ticking timebomb.  It has methods
 `.start()`, `.stop()` and `.touch()` and emits `started`, `expired`, `stopped`
 and `touched`.  What it allows an implementor is the abilty to say that while
-the absolute maximum iteration interval (`maxIterationTime`), incremental 
+the absolute maximum iteration interval (`maxIterationTime`), incremental
 progress should be made.  The idea here is that after each chunk of work in the
 handler, you run `.touch()`.  This way, you can have a handler that can be
 marked as failing without waiting the full `maxIterationTime`.  The delay for
@@ -111,4 +115,3 @@ There are a couple things that I`d like to do to this library
   down easier.  Right now, we emit `stopped` on success and `stopped` *and*
   `error` on failure.  We should either emit only one of `stopped` and `error`
   or have the above mentioned events
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskcluster-lib-iterate",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A library to share iteration logic",
   "main": "lib/iterate.js",
   "scripts": {
@@ -8,22 +8,28 @@
     "prepublish": "npm run compile",
     "test": "npm run compile && mocha .test/*_test.js"
   },
+  "repository": {
+     "type": "git",
+     "url": "https://github.com/taskcluster/taskcluster-lib-iterate.git"
+   },
   "keywords": [
     "taskcluster"
   ],
   "author": "John Ford <jhford@mozilla.com>",
   "license": "MPL-2.0",
   "dependencies": {
-    "assume": "^1.4.1",
     "babel-compile": "^2.0.0",
     "babel-preset-taskcluster": "^3.0.0",
     "babel-runtime": "^6.9.2",
     "bluebird": "^3.4.1",
     "debug": "^2.2.0",
     "lodash": "^4.13.1",
-    "mocha": "^2.5.3",
     "request": "^2.73.0",
-    "request-promise": "^3.0.0",
+    "request-promise": "^3.0.0"
+  },
+  "devDependencies": {
+    "assume": "^1.4.1",
+    "mocha": "^2.5.3",
     "sinon": "^1.17.4",
     "source-map-support": "^0.4.1"
   }

--- a/package.json
+++ b/package.json
@@ -18,8 +18,6 @@
   "author": "John Ford <jhford@mozilla.com>",
   "license": "MPL-2.0",
   "dependencies": {
-    "babel-compile": "^2.0.0",
-    "babel-preset-taskcluster": "^3.0.0",
     "babel-runtime": "^6.9.2",
     "bluebird": "^3.4.1",
     "debug": "^2.2.0",
@@ -28,6 +26,8 @@
     "request-promise": "^3.0.0"
   },
   "devDependencies": {
+    "babel-compile": "^2.0.0",
+    "babel-preset-taskcluster": "^3.0.0",
     "assume": "^1.4.1",
     "mocha": "^2.5.3",
     "sinon": "^1.17.4",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "assume": "^1.4.1",
     "mocha": "^2.5.3",
     "sinon": "^1.17.4",
-    "source-map-support": "^0.4.1"
+    "source-map-support": "^0.4.1",
+    "taskcluster-lib-monitor": "^3.1.0"
   }
 }


### PR DESCRIPTION
We can probably add a lot of other interesting metrics here...

But with this we at-least get something...
Also it's possible to configure signalfx to alert if `successful-iteration` is zero for say 30 min... This can replace deadmans snitch... This is only interesting because config  is easier as monitor does the auth stuff... and you can have list of alerts in signalfx...
