### PR TITLE
add a files section to package.json to exclude junk from publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 /user-config.yml
 /node_modules/
 provisioner-test-*.pem
-.test
+.test/
 
 # Logs
 logs
@@ -31,3 +31,4 @@ node_modules
 Session.vim
 .netrwhist
 *~
+lib/

--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     "prepare": "yarn compile",
     "test": "yarn compile && mocha .test/*_test.js"
   },
+  "files": [
+    "src",
+    "lib"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/taskcluster/taskcluster-lib-iterate.git"


### PR DESCRIPTION
Similar to https://github.com/taskcluster/taskcluster-lib-log/pull/4 for the `files` section, but more importantly, please run `npm access-grant read-write taskcluster:developers` so that Travis can release on tag.