### PR TITLE
Allow normal monorepo usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "lib/iterate.js",
   "scripts": {
     "lint": "eslint src/*.js test/*.js",
-    "test": "yarn run lint && mocha"
+    "pretest": "yarn lint",
+    "test": "mocha"
   },
   "files": [
     "lib/iterate.js",


### PR DESCRIPTION
This just brings this in line with our other projects which makes it a bit easier for me to programmatically import it.