### PR TITLE
fix the require() in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ fail too many times and does not fail silently.
 Here is a simple example of this library:
 
 ```javascript
-var Iterate = require(`./`);
+var Iterate = require(`taskcluster-lib-iterate`);
 
 i = new Iterate({
   maxFailures: 5,


### PR DESCRIPTION
```
16:45:33 <hybrid1999> I am not sure how to use the iterate library
16:46:06 <hybrid1999> only the importing the lbrary part
16:47:57 <hybrid1999> I dont know how this statement in particular works
16:48:01 <hybrid1999> : var Iterate = require(`./`);
```